### PR TITLE
Fix example scripts to resolve package imports without installation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "isk-montecarlo",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {}
+  },
+  "postCreateCommand": "pip install -r requirements.txt",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.analysis.typeCheckingMode": "basic"
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-toolsai.jupyter"
+      ]
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+setup:
+	pip install -r requirements.txt
+
+run-monthly:
+	python examples/run_monthly.py
+
+run-daily:
+	python examples/run_daily.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
 # isk-montecarlo
+
+Monte Carlo simulator for Swedish FIRE with **ISK** accounts:
+
+- Inflation-indexed monthly deposits
+- ISK tax drag
+- Normal or **fat-tailed, left-skewed** (split-t) return models
+- Daily or monthly granularity
+- Reproducible charts (paths, histograms, time-to-target)
+
+## Quick start
+
+```bash
+pip install -r requirements.txt
+python examples/run_monthly.py  # or examples/run_daily.py
+```
+
+The repo ships with an optional `environment.yml` (conda) and `.devcontainer/` setup for GitHub Codespaces. Both install the same dependencies as `requirements.txt`.
+
+## Project structure
+
+```
+isk-montecarlo/
+├─ src/isk_montecarlo/
+│  ├─ config.py          # dataclasses for parameters & defaults
+│  ├─ models.py          # normal & split-t return generators
+│  ├─ simulate.py        # monthly/daily engines with ISK/inflation logic
+│  ├─ plots.py           # histograms, wealth-path charts, CAGR plots
+│  └─ tax.py             # Swedish tax & pension contribution helpers
+├─ examples/
+│  ├─ run_monthly.py     # argparse CLI for monthly Monte Carlo
+│  ├─ run_daily.py       # argparse CLI for daily Monte Carlo + CAGR
+│  └─ plot_tax.py        # progressive tax & pension contribution charts
+├─ notebooks/            # optional exploratory notebooks
+├─ requirements.txt
+├─ environment.yml
+├─ Makefile
+└─ .devcontainer/devcontainer.json
+```
+
+## Key CLI parameters
+
+### Core financial
+
+- `--start-balance` (e.g., `1_100_000`)
+- `--monthly-deposit` (today’s SEK; indexed to inflation internally)
+- `--target-real` (e.g., `15_000_000`)
+- `--inflation` (default `0.02`)
+- `--isk-tax` (default `0.009`)
+
+### Return model
+
+- `--model` = `normal` | `split_t`
+- Arithmetic mean: `--arith-mean-annual` (default `0.1164`)
+- Volatility: `--stdev-annual` (default `0.1949`)
+- Split-t extras: `--df`, `--asym` plus per-frequency overrides (`--df-monthly`, `--asym-monthly`, `--df-daily`, `--asym-daily`)
+
+### Simulation
+
+- `--granularity` is implied by the script (`run_monthly.py` or `run_daily.py`)
+- `--trading-days-per-year` (daily script, default `250`)
+- `--years` (default `40`)
+- `--sims` (default `10_000`)
+- `--seed` (reproducibility)
+- `--progress/--no-progress`
+- `--truncate/--no-truncate` (plotting only)
+
+### Plotting & outputs
+
+- `--save-plots` (folder path)
+- `--show/--no-show` (render to screen)
+- `--bins` (histogram bins)
+- `--subset` (number of paths to draw, e.g., `200`)
+
+### Tax utilities
+
+Run `python examples/plot_tax.py` for progressive tax, marginal/average rate, and pension contribution charts across a salary range. Use `--max-salary` and `--points` to change the grid.
+
+## Sensible defaults
+
+- Annual arithmetic mean: **0.1164**
+- Annual stdev: **0.1949**
+- Inflation: **0.02**
+- ISK tax: **0.009**
+- Split-t default: `df=5`, `asym=1.3`
+- Horizon: **40 years**
+- Sims: **10,000**
+- Seed: **123**
+
+## Development helpers
+
+- `make setup` – install dependencies via pip
+- `make run-monthly` – run the monthly CLI with defaults
+- `make run-daily` – run the daily CLI with defaults
+
+All Python code is formatted with `ruff format` and linted with `ruff check`. Run both commands before committing changes.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: isk-montecarlo
+channels: [conda-forge]
+dependencies:
+  - python=3.11
+  - numpy>=1.26
+  - matplotlib>=3.8
+  - tqdm>=4.66
+  - scipy>=1.11
+  - pandas>=2.2

--- a/examples/_paths.py
+++ b/examples/_paths.py
@@ -1,0 +1,26 @@
+"""Utilities for configuring import paths in example scripts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+
+
+def add_src_to_syspath() -> None:
+    """Ensure the repository's ``src`` directory is on ``sys.path``.
+
+    This allows running the example scripts directly via ``python examples/foo.py``
+    without needing to install the package first.
+    """
+
+    src_str = str(SRC_PATH)
+    if SRC_PATH.is_dir() and src_str not in sys.path:
+        sys.path.insert(0, src_str)
+
+
+add_src_to_syspath()
+
+
+__all__ = ["add_src_to_syspath"]

--- a/examples/plot_tax.py
+++ b/examples/plot_tax.py
@@ -1,0 +1,100 @@
+"""Visualize Swedish tax, pension, and BTP1 contributions across salary levels."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+import _paths  # noqa: F401
+import matplotlib.pyplot as plt
+import numpy as np
+
+from isk_montecarlo.plots import maybe_show, save_figure
+from isk_montecarlo.tax import TaxParameters, TaxProfiles, compute_profiles
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-salary", type=float, default=250_000.0, help="Maximum monthly salary to plot"
+    )
+    parser.add_argument(
+        "--points", type=int, default=2_000, help="Number of salary points to evaluate"
+    )
+    parser.add_argument("--save-plots", type=Path)
+    parser.add_argument("--show", action=argparse.BooleanOptionalAction, default=False)
+    return parser.parse_args()
+
+
+def plot_income_and_pension(profiles: TaxProfiles) -> plt.Figure:
+    fig, ax = plt.subplots(figsize=(11, 6.5))
+    ax.plot(
+        profiles.gross_monthly,
+        profiles.net_monthly,
+        label="After-tax income (Stockholm 2025 model)",
+    )
+    ax.plot(
+        profiles.gross_monthly,
+        profiles.public_pension,
+        label="Public pension contribution (18.5% of PGI)",
+    )
+    ax.plot(profiles.gross_monthly, profiles.btp1_low, label="BTP1: 6.5% part (≤ 7.5 IBB)")
+    ax.plot(profiles.gross_monthly, profiles.btp1_high, label="BTP1: 32% part (7.5–30 IBB)")
+    ax.plot(profiles.gross_monthly, profiles.btp1_total, label="BTP1: total contribution")
+
+    ymax = ax.get_ylim()[1]
+    for label, xval in profiles.monthly_breakpoints().items():
+        ax.axvline(x=xval, linestyle="--")
+        ax.text(xval, ymax * 0.05, label, rotation=90, va="bottom", ha="right")
+
+    ax.set_title("Sweden 2025 (Stockholm): Net income & pension vs monthly salary")
+    ax.set_xlabel("Monthly gross salary (SEK)")
+    ax.set_ylabel("SEK per month")
+    ax.grid(True, linestyle=":")
+    ax.legend(loc="upper left")
+    fig.tight_layout()
+    return fig
+
+
+def plot_tax_rates(profiles: TaxProfiles) -> plt.Figure:
+    fig, ax = plt.subplots(figsize=(11, 6.5))
+    ax.plot(profiles.gross_monthly, profiles.average_rate, label="Average tax rate")
+    ax.plot(profiles.gross_monthly, profiles.marginal_rate, label="Marginal tax rate")
+
+    ymax = ax.get_ylim()[1] if ax.get_ylim()[1] > 0 else 1.0
+    for label, xval in profiles.monthly_breakpoints().items():
+        ax.axvline(x=xval, linestyle="--")
+        ax.text(xval, ymax * 0.05, label, rotation=90, va="bottom", ha="right")
+
+    ax.set_title("Sweden 2025 (Stockholm): Average & marginal tax rates")
+    ax.set_xlabel("Monthly gross salary (SEK)")
+    ax.set_ylabel("Tax rate")
+    ax.grid(True, linestyle=":")
+    ax.legend()
+    fig.tight_layout()
+    return fig
+
+
+def main() -> None:
+    args = parse_args()
+    params = TaxParameters()
+    gross = np.linspace(0.0, args.max_salary, args.points)
+    profiles = compute_profiles(gross, params=params)
+
+    figures: List = []
+    fig_income = plot_income_and_pension(profiles)
+    figures.append(("income_pension", fig_income))
+    fig_rates = plot_tax_rates(profiles)
+    figures.append(("tax_rates", fig_rates))
+
+    if args.save_plots:
+        for name, fig in figures:
+            path = args.save_plots / f"{name}.png"
+            save_figure(fig, path)
+
+    maybe_show([fig for _, fig in figures], show=args.show)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/run_daily.py
+++ b/examples/run_daily.py
@@ -1,0 +1,144 @@
+"""Run daily ISK Monte Carlo simulations and equity CAGR experiments."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+import _paths  # noqa: F401
+from numpy.random import default_rng
+
+from isk_montecarlo.config import (
+    Granularity,
+    PlotConfig,
+    ReturnModelConfig,
+    ReturnModelType,
+    SimulationConfig,
+)
+from isk_montecarlo.models import generate_equity_cagr
+from isk_montecarlo.plots import (
+    maybe_show,
+    plot_cagr_distribution,
+    plot_paths,
+    plot_years_to_target,
+    save_figure,
+)
+from isk_montecarlo.simulate import run_daily_simulation
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start-balance", type=float, default=1_100_000.0)
+    parser.add_argument("--monthly-deposit", type=float, default=25_000.0)
+    parser.add_argument("--target-real", type=float, default=15_000_000.0)
+    parser.add_argument("--inflation", type=float, default=0.02)
+    parser.add_argument("--isk-tax", type=float, default=0.009)
+    parser.add_argument("--years", type=int, default=40)
+    parser.add_argument("--sims", type=int, default=10_000)
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--trading-days-per-year", type=int, default=250)
+    parser.add_argument("--progress", action=argparse.BooleanOptionalAction, default=True)
+
+    parser.add_argument(
+        "--model", choices=[m.value for m in ReturnModelType], default=ReturnModelType.SPLIT_T.value
+    )
+    parser.add_argument("--arith-mean-annual", type=float, default=0.1164)
+    parser.add_argument("--stdev-annual", type=float, default=0.1949)
+    parser.add_argument("--df", type=positive_float, default=5.0)
+    parser.add_argument("--asym", type=positive_float, default=1.2)
+    parser.add_argument("--df-daily", type=positive_float, default=None)
+    parser.add_argument("--asym-daily", type=positive_float, default=None)
+
+    parser.add_argument("--cagr-sims", type=int, default=12_000)
+    parser.add_argument("--bins", type=int, default=50)
+    parser.add_argument("--subset", type=int, default=200)
+    parser.add_argument("--no-truncate", dest="truncate", action="store_false")
+    parser.set_defaults(truncate=True)
+    parser.add_argument("--save-plots", type=Path)
+    parser.add_argument("--show", action=argparse.BooleanOptionalAction, default=False)
+    return parser.parse_args()
+
+
+def build_configs(
+    args: argparse.Namespace,
+) -> tuple[SimulationConfig, ReturnModelConfig, PlotConfig]:
+    model_type = ReturnModelType(args.model)
+    return_config = ReturnModelConfig(
+        model=model_type,
+        arith_mean_annual=args.arith_mean_annual,
+        stdev_annual=args.stdev_annual,
+        df=args.df,
+        asym=args.asym,
+        daily_df=args.df_daily,
+        daily_asym=args.asym_daily,
+    )
+
+    sim_config = SimulationConfig(
+        start_balance=args.start_balance,
+        monthly_deposit=args.monthly_deposit,
+        target_real=args.target_real,
+        inflation=args.inflation,
+        isk_tax=args.isk_tax,
+        years=args.years,
+        sims=args.sims,
+        granularity=Granularity.DAILY,
+        trading_days_per_year=args.trading_days_per_year,
+        seed=args.seed,
+        progress=args.progress,
+    )
+
+    plot_config = PlotConfig(
+        bins=args.bins,
+        subset_paths=args.subset,
+        truncate_paths=args.truncate,
+        save_plots=args.save_plots,
+        show=args.show,
+    )
+    return sim_config, return_config, plot_config
+
+
+def main() -> None:
+    args = parse_args()
+    sim_config, model_config, plot_config = build_configs(args)
+    result = run_daily_simulation(sim_config, model_config)
+
+    figures: List = []
+    fig_paths = plot_paths(
+        result,
+        plot_config,
+        rng=default_rng(sim_config.seed + 1 if sim_config.seed is not None else None),
+        title="Daily Monte Carlo (real SEK) — split-t or normal returns",
+    )
+    figures.append(("daily_paths", fig_paths))
+    fig_hist = plot_years_to_target(result, plot_config)
+    figures.append(("daily_years_to_target", fig_hist))
+
+    cagr_rng = default_rng(sim_config.seed + 2 if sim_config.seed is not None else None)
+    cagrs = generate_equity_cagr(
+        model_config,
+        years=sim_config.years,
+        sims=args.cagr_sims,
+        trading_days_per_year=sim_config.trading_days_per_year,
+        rng=cagr_rng,
+    )
+    fig_cagr = plot_cagr_distribution(cagrs, bins=plot_config.bins)
+    figures.append(("daily_cagr", fig_cagr))
+
+    if plot_config.save_plots:
+        for name, fig in figures:
+            path = plot_config.save_plots / f"{name}.png"
+            save_figure(fig, path)
+
+    maybe_show([fig for _, fig in figures], show=plot_config.show)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/run_monthly.py
+++ b/examples/run_monthly.py
@@ -1,0 +1,165 @@
+"""Run monthly ISK Monte Carlo simulations with configurable parameters."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import TYPE_CHECKING, List
+
+import _paths  # noqa: F401
+from numpy.random import default_rng
+
+from isk_montecarlo.config import (
+    Granularity,
+    PlotConfig,
+    ReturnModelConfig,
+    ReturnModelType,
+    SimulationConfig,
+)
+from isk_montecarlo.models import build_return_sampler
+from isk_montecarlo.plots import (
+    maybe_show,
+    plot_paths,
+    plot_return_distribution,
+    plot_years_to_target,
+    save_figure,
+)
+from isk_montecarlo.simulate import run_monthly_simulation
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start-balance", type=float, default=1_100_000.0)
+    parser.add_argument("--monthly-deposit", type=float, default=25_000.0)
+    parser.add_argument("--target-real", type=float, default=15_000_000.0)
+    parser.add_argument("--inflation", type=float, default=0.02)
+    parser.add_argument("--isk-tax", type=float, default=0.009)
+    parser.add_argument("--years", type=int, default=40)
+    parser.add_argument("--sims", type=int, default=10_000)
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--progress", action=argparse.BooleanOptionalAction, default=True)
+
+    parser.add_argument(
+        "--model", choices=[m.value for m in ReturnModelType], default=ReturnModelType.SPLIT_T.value
+    )
+    parser.add_argument("--arith-mean-annual", type=float, default=0.1164)
+    parser.add_argument("--stdev-annual", type=float, default=0.1949)
+    parser.add_argument(
+        "--df", type=positive_float, default=5.0, help="Degrees of freedom for split-t"
+    )
+    parser.add_argument(
+        "--asym", type=positive_float, default=1.3, help="Asymmetry (>1 => heavier left tail)"
+    )
+    parser.add_argument("--df-monthly", type=positive_float, default=None)
+    parser.add_argument("--asym-monthly", type=positive_float, default=None)
+
+    parser.add_argument("--distribution-sample", type=int, default=60_000)
+    parser.add_argument("--bins", type=int, default=40)
+    parser.add_argument("--subset", type=int, default=200)
+    parser.add_argument("--no-truncate", dest="truncate", action="store_false")
+    parser.set_defaults(truncate=True)
+    parser.add_argument("--save-plots", type=Path)
+    parser.add_argument("--show", action=argparse.BooleanOptionalAction, default=False)
+    return parser.parse_args()
+
+
+def build_configs(
+    args: argparse.Namespace,
+) -> tuple[SimulationConfig, ReturnModelConfig, PlotConfig]:
+    model_type = ReturnModelType(args.model)
+    return_config = ReturnModelConfig(
+        model=model_type,
+        arith_mean_annual=args.arith_mean_annual,
+        stdev_annual=args.stdev_annual,
+        df=args.df,
+        asym=args.asym,
+        monthly_df=args.df_monthly,
+        monthly_asym=args.asym_monthly,
+    )
+
+    sim_config = SimulationConfig(
+        start_balance=args.start_balance,
+        monthly_deposit=args.monthly_deposit,
+        target_real=args.target_real,
+        inflation=args.inflation,
+        isk_tax=args.isk_tax,
+        years=args.years,
+        sims=args.sims,
+        granularity=Granularity.MONTHLY,
+        trading_days_per_year=250,
+        seed=args.seed,
+        progress=args.progress,
+    )
+
+    plot_config = PlotConfig(
+        bins=args.bins,
+        subset_paths=args.subset,
+        truncate_paths=args.truncate,
+        save_plots=args.save_plots,
+        show=args.show,
+    )
+    return sim_config, return_config, plot_config
+
+
+def sample_monthly_returns(
+    config: SimulationConfig,
+    model_config: ReturnModelConfig,
+    *,
+    sample_size: int,
+) -> "np.ndarray":
+    rng_seed = None if config.seed is None else config.seed + 1
+    rng = default_rng(rng_seed)
+    sampler = build_return_sampler(
+        model_config,
+        Granularity.MONTHLY,
+        trading_days_per_year=config.trading_days_per_year,
+        rng=rng,
+    )
+    returns = sampler(sample_size)
+    return returns - config.isk_tax / 12.0
+
+
+def main() -> None:
+    args = parse_args()
+    sim_config, model_config, plot_config = build_configs(args)
+    result = run_monthly_simulation(sim_config, model_config)
+
+    monthly_returns = sample_monthly_returns(
+        sim_config,
+        model_config,
+        sample_size=args.distribution_sample,
+    )
+
+    figures: List = []
+    fig_dist = plot_return_distribution(monthly_returns, bins=args.bins)
+    figures.append(("monthly_distribution", fig_dist))
+    fig_paths = plot_paths(
+        result,
+        plot_config,
+        rng=default_rng(sim_config.seed + 2 if sim_config.seed is not None else None),
+        title="Monthly Monte Carlo (real SEK) — split-t or normal returns",
+    )
+    figures.append(("monthly_paths", fig_paths))
+    fig_hist = plot_years_to_target(result, plot_config)
+    figures.append(("monthly_years_to_target", fig_hist))
+
+    if plot_config.save_plots:
+        for name, fig in figures:
+            path = plot_config.save_plots / f"{name}.png"
+            save_figure(fig, path)
+
+    maybe_show([fig for _, fig in figures], show=plot_config.show)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy>=1.26
+matplotlib>=3.8
+tqdm>=4.66
+scipy>=1.11
+pandas>=2.2

--- a/src/isk_montecarlo/__init__.py
+++ b/src/isk_montecarlo/__init__.py
@@ -1,0 +1,11 @@
+"""Core package for the ISK Monte Carlo simulator."""
+
+from . import config, models, plots, simulate, tax
+
+__all__ = [
+    "config",
+    "models",
+    "plots",
+    "simulate",
+    "tax",
+]

--- a/src/isk_montecarlo/config.py
+++ b/src/isk_montecarlo/config.py
@@ -1,0 +1,79 @@
+"""Configuration objects for the ISK Monte Carlo simulator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+class Granularity(str, Enum):
+    """Supported simulation step sizes."""
+
+    MONTHLY = "monthly"
+    DAILY = "daily"
+
+
+class ReturnModelType(str, Enum):
+    """Available stochastic return models."""
+
+    NORMAL = "normal"
+    SPLIT_T = "split_t"
+
+
+@dataclass(slots=True)
+class ReturnModelConfig:
+    """Parameters that describe the desired return distribution."""
+
+    model: ReturnModelType = ReturnModelType.SPLIT_T
+    arith_mean_annual: float = 0.1164
+    stdev_annual: float = 0.1949
+    df: float = 5.0
+    asym: float = 1.3
+    monthly_df: Optional[float] = None
+    monthly_asym: Optional[float] = None
+    daily_df: Optional[float] = None
+    daily_asym: Optional[float] = None
+
+
+@dataclass(slots=True)
+class SimulationConfig:
+    """Parameters that drive the wealth-accumulation simulation."""
+
+    start_balance: float = 1_100_000.0
+    monthly_deposit: float = 25_000.0
+    target_real: float = 15_000_000.0
+    inflation: float = 0.02
+    isk_tax: float = 0.009
+    years: int = 40
+    sims: int = 10_000
+    granularity: Granularity = Granularity.MONTHLY
+    trading_days_per_year: int = 250
+    seed: Optional[int] = 123
+    progress: bool = True
+
+
+@dataclass(slots=True)
+class PlotConfig:
+    """Options that control how plots are rendered and persisted."""
+
+    bins: int = 40
+    subset_paths: int = 200
+    truncate_paths: bool = True
+    save_plots: Optional[Path] = None
+    show: bool = False
+
+
+@dataclass(slots=True)
+class CAGRConfig:
+    """Parameters for stand-alone equity CAGR simulations."""
+
+    years: int = 40
+    sims: int = 12_000
+
+
+DEFAULT_RETURN_MODEL = ReturnModelConfig()
+DEFAULT_SIMULATION = SimulationConfig()
+DEFAULT_PLOT = PlotConfig()
+DEFAULT_CAGR = CAGRConfig()

--- a/src/isk_montecarlo/models.py
+++ b/src/isk_montecarlo/models.py
@@ -1,0 +1,96 @@
+"""Return models used in the ISK Monte Carlo simulator."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+from numpy.random import Generator
+
+from .config import Granularity, ReturnModelConfig, ReturnModelType
+
+
+def _scale_mean(mean: float, periods: int) -> float:
+    return mean / periods
+
+
+def _scale_stdev(stdev: float, periods: int) -> float:
+    return stdev / np.sqrt(periods)
+
+
+def _sample_student_t(df: float, size: int, rng: Generator) -> np.ndarray:
+    z = rng.normal(0.0, 1.0, size)
+    u = rng.chisquare(df, size)
+    return z / np.sqrt(u / df)
+
+
+def _calibrate_split_t(
+    df: float, asym: float, rng: Generator, *, size: int = 200_000
+) -> Callable[[int], np.ndarray]:
+    baseline = _sample_student_t(df, size, rng)
+    stretched = np.where(baseline < 0, asym * baseline, baseline / asym)
+    mean = stretched.mean()
+    std = stretched.std(ddof=1)
+
+    def draw(n: int) -> np.ndarray:
+        sample = _sample_student_t(df, n, rng)
+        stretched_sample = np.where(sample < 0, asym * sample, sample / asym)
+        return (stretched_sample - mean) / std
+
+    return draw
+
+
+def build_return_sampler(
+    config: ReturnModelConfig,
+    granularity: Granularity,
+    *,
+    trading_days_per_year: int,
+    rng: Generator,
+) -> Callable[[int], np.ndarray]:
+    """Return a callable that generates arithmetic returns for the requested granularity."""
+
+    if granularity is Granularity.MONTHLY:
+        periods = 12
+        df = config.monthly_df or config.df
+        asym = config.monthly_asym or config.asym
+    else:
+        periods = trading_days_per_year
+        df = config.daily_df or config.df
+        asym = config.daily_asym or config.asym
+
+    mean = _scale_mean(config.arith_mean_annual, periods)
+    stdev = _scale_stdev(config.stdev_annual, periods)
+
+    if config.model is ReturnModelType.NORMAL:
+        return lambda n: rng.normal(mean, stdev, n)
+
+    if config.model is ReturnModelType.SPLIT_T:
+        standardized = _calibrate_split_t(df=df, asym=asym, rng=rng)
+        return lambda n: mean + stdev * standardized(n)
+
+    raise ValueError(f"Unsupported return model: {config.model}")
+
+
+def generate_equity_cagr(
+    config: ReturnModelConfig,
+    *,
+    years: int,
+    sims: int,
+    trading_days_per_year: int,
+    rng: Generator,
+) -> np.ndarray:
+    """Simulate equity-only CAGRs using the configured return model."""
+
+    draw_daily = build_return_sampler(
+        config,
+        Granularity.DAILY,
+        trading_days_per_year=trading_days_per_year,
+        rng=rng,
+    )
+    days = years * trading_days_per_year
+    cagr = np.empty(sims)
+    for idx in range(sims):
+        returns = draw_daily(days)
+        growth = float(np.prod(1.0 + returns))
+        cagr[idx] = growth ** (1.0 / years) - 1.0
+    return cagr

--- a/src/isk_montecarlo/plots.py
+++ b/src/isk_montecarlo/plots.py
@@ -1,0 +1,167 @@
+"""Plotting helpers for the ISK Monte Carlo simulator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.ticker import PercentFormatter
+from numpy.random import Generator, default_rng
+
+from .config import PlotConfig
+from .simulate import SimulationResult, find_cross_index
+
+
+def _get_axes(ax: Optional[Axes]) -> tuple[Figure, Axes]:
+    if ax is None:
+        fig, axis = plt.subplots()
+    else:
+        axis = ax
+        fig = ax.figure
+    return fig, axis
+
+
+def plot_return_distribution(
+    returns: np.ndarray,
+    *,
+    bins: int = 120,
+    ax: Optional[Axes] = None,
+) -> Figure:
+    """Plot a normalized histogram of monthly returns."""
+
+    fig, axis = _get_axes(ax)
+    counts, bin_edges = np.histogram(returns, bins=bins)
+    if counts.max() == 0:
+        normalized = counts
+    else:
+        normalized = counts / counts.max()
+    centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
+    width = (bin_edges[1] - bin_edges[0]) * 0.95
+    axis.bar(centers, normalized, width=width, edgecolor="black", alpha=0.8)
+    axis.axvline(returns.mean(), linestyle="--", label=f"Mean ~{returns.mean():.2%}")
+    axis.set_title("Implied Return Distribution — Normalized height (max = 1)")
+    axis.set_xlabel("Return per period")
+    axis.set_ylabel("Normalized frequency")
+    axis.xaxis.set_major_formatter(PercentFormatter(1.0))
+    axis.set_ylim(0.0, 1.0)
+    axis.grid(alpha=0.3)
+    axis.legend()
+    return fig
+
+
+def plot_paths(
+    result: SimulationResult,
+    plot_config: PlotConfig,
+    *,
+    rng: Optional[Generator] = None,
+    title: str,
+    ylabel: str = "Portfolio value (real SEK)",
+) -> Figure:
+    """Plot a subset of simulated wealth paths together with the mean/median."""
+
+    fig, axis = plt.subplots(figsize=(9, 6))
+    rng = default_rng() if rng is None else rng
+
+    subset = min(plot_config.subset_paths, result.paths_real.shape[0])
+    indices = rng.choice(result.paths_real.shape[0], subset, replace=False)
+    for idx in indices:
+        cross = result.crossing_index[idx]
+        if plot_config.truncate_paths and cross >= 0:
+            axis.plot(
+                result.years_axis[: cross + 1],
+                result.paths_real[idx, : cross + 1],
+                linewidth=0.7,
+                alpha=0.2,
+            )
+        else:
+            axis.plot(result.years_axis, result.paths_real[idx, :], linewidth=0.7, alpha=0.2)
+
+    median_path = result.median_path()
+    mean_path = result.mean_path()
+    median_cross = find_cross_index(median_path, result.target)
+    mean_cross = find_cross_index(mean_path, result.target)
+
+    def _plot_line(path: np.ndarray, cross: int, **kwargs: float) -> None:
+        if plot_config.truncate_paths and cross >= 0:
+            axis.plot(result.years_axis[: cross + 1], path[: cross + 1], **kwargs)
+        else:
+            axis.plot(result.years_axis, path, **kwargs)
+
+    _plot_line(median_path, median_cross, linewidth=2.2, linestyle="--", label="Median path (real)")
+    _plot_line(mean_path, mean_cross, linewidth=2.2, linestyle="-", label="Mean path (real)")
+
+    axis.axhline(result.target, linestyle=":", label=f"Target: {result.target:,.0f} SEK (real)")
+    axis.set_title(title)
+    axis.set_xlabel("Years from today")
+    axis.set_ylabel(ylabel)
+    axis.legend()
+    axis.grid(alpha=0.3)
+    return fig
+
+
+def plot_years_to_target(
+    result: SimulationResult,
+    plot_config: PlotConfig,
+    *,
+    ax: Optional[Axes] = None,
+) -> Figure:
+    """Plot the distribution of years required to hit the wealth target."""
+
+    years = result.years_to_target()
+    fig, axis = _get_axes(ax)
+    if years.size == 0:
+        axis.text(
+            0.5, 0.5, "Target not reached", transform=axis.transAxes, ha="center", va="center"
+        )
+        axis.set_axis_off()
+        return fig
+
+    percentiles = result.percentile_years((10, 50, 90))
+    axis.hist(years, bins=plot_config.bins, edgecolor="black", alpha=0.7, density=True)
+    axis.axvline(percentiles[0], linestyle="--", label=f"10th %ile ~{percentiles[0]:.1f} yrs")
+    axis.axvline(percentiles[1], linestyle="--", label=f"Median ~{percentiles[1]:.1f} yrs")
+    axis.axvline(percentiles[2], linestyle="--", label=f"90th %ile ~{percentiles[2]:.1f} yrs")
+    axis.set_title("Distribution of years to hit the target (real SEK)")
+    axis.set_xlabel("Years to reach target")
+    axis.set_ylabel("Probability density")
+    axis.grid(alpha=0.3)
+    axis.legend()
+    return fig
+
+
+def plot_cagr_distribution(
+    cagrs: np.ndarray, *, bins: int = 60, ax: Optional[Axes] = None
+) -> Figure:
+    """Plot the simulated equity CAGR distribution."""
+
+    fig, axis = _get_axes(ax)
+    axis.hist(cagrs, bins=bins, edgecolor="black", alpha=0.7)
+    median = float(np.median(cagrs))
+    p10, p90 = np.percentile(cagrs, [10, 90])
+    axis.axvline(median, linestyle="--", label=f"Median CAGR ~{median:.2%}")
+    axis.axvline(p10, linestyle=":", label=f"10th %ile ~{p10:.2%}")
+    axis.axvline(p90, linestyle=":", label=f"90th %ile ~{p90:.2%}")
+    axis.set_title("Equity CAGR distribution")
+    axis.set_xlabel("Annualized return")
+    axis.set_ylabel("Frequency")
+    axis.xaxis.set_major_formatter(PercentFormatter(1.0))
+    axis.grid(alpha=0.3)
+    axis.legend()
+    return fig
+
+
+def save_figure(fig: Figure, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+
+
+def maybe_show(figures: Iterable[Figure], *, show: bool) -> None:
+    if show:
+        plt.show()
+    else:
+        for fig in figures:
+            plt.close(fig)

--- a/src/isk_montecarlo/simulate.py
+++ b/src/isk_montecarlo/simulate.py
@@ -1,0 +1,173 @@
+"""Simulation engines for ISK Monte Carlo experiments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Iterable
+
+import numpy as np
+from numpy.random import Generator, default_rng
+
+from .config import Granularity, ReturnModelConfig, SimulationConfig
+from .models import build_return_sampler
+
+try:
+    from tqdm import trange
+except Exception:  # pragma: no cover - tqdm optional
+    trange = None
+
+
+@dataclass(slots=True)
+class SimulationResult:
+    """Holds full simulation paths and useful metadata."""
+
+    paths_real: np.ndarray
+    crossing_index: np.ndarray
+    years_axis: np.ndarray
+    periods_per_year: float
+    target: float
+
+    def valid_crossings(self) -> np.ndarray:
+        mask = self.crossing_index >= 0
+        return self.crossing_index[mask]
+
+    def years_to_target(self) -> np.ndarray:
+        crossings = self.valid_crossings()
+        if crossings.size == 0:
+            return np.array([], dtype=float)
+        return crossings / self.periods_per_year
+
+    def percentile_years(self, percentiles: Iterable[float]) -> np.ndarray:
+        years = self.years_to_target()
+        percentiles = list(percentiles)
+        if years.size == 0:
+            return np.full(len(percentiles), np.nan)
+        return np.percentile(years, percentiles)
+
+    def mean_path(self) -> np.ndarray:
+        return np.nanmean(self.paths_real, axis=0)
+
+    def median_path(self) -> np.ndarray:
+        return np.nanmedian(self.paths_real, axis=0)
+
+
+def _iter_range(total: int, *, show_progress: bool) -> Iterable[int]:
+    if show_progress and trange is not None:
+        return trange(total, desc="Simulations")
+    return range(total)
+
+
+def _inflation_factor(rate: float, years: np.ndarray) -> np.ndarray:
+    return np.asarray((1.0 + rate) ** years, dtype=np.float64)
+
+
+def _apply_isk_tax(returns: np.ndarray, isk_tax: float, periods_per_year: float) -> np.ndarray:
+    return returns - isk_tax / periods_per_year
+
+
+def _run_simulation(
+    config: SimulationConfig,
+    model_config: ReturnModelConfig,
+    granularity: Granularity,
+    *,
+    rng: Generator,
+) -> SimulationResult:
+    if granularity is Granularity.MONTHLY:
+        periods_per_year = 12
+        periods = config.years * periods_per_year
+        years_axis = np.arange(periods, dtype=float) / periods_per_year
+        deposit_years = years_axis
+        draw_returns = build_return_sampler(
+            model_config,
+            Granularity.MONTHLY,
+            trading_days_per_year=config.trading_days_per_year,
+            rng=rng,
+        )
+    else:
+        periods_per_year = float(config.trading_days_per_year)
+        periods = int(config.years * periods_per_year)
+        years_axis = np.arange(periods, dtype=float) / periods_per_year
+        deposit_years = np.floor(years_axis * 12.0) / 12.0
+        draw_returns = build_return_sampler(
+            model_config,
+            Granularity.DAILY,
+            trading_days_per_year=config.trading_days_per_year,
+            rng=rng,
+        )
+
+    paths_real = np.zeros((config.sims, periods), dtype=float)
+    crossing_index = np.full(config.sims, -1, dtype=int)
+
+    inflation_years = years_axis if granularity is Granularity.MONTHLY else years_axis
+    inflation_factor = _inflation_factor(config.inflation, inflation_years)
+
+    progress_iter = _iter_range(config.sims, show_progress=config.progress)
+    for sim_idx in progress_iter:
+        returns = draw_returns(periods)
+        returns = _apply_isk_tax(returns, config.isk_tax, periods_per_year)
+        balance_nominal = config.start_balance
+        crossed = False
+        for period in range(periods):
+            balance_nominal *= 1.0 + returns[period]
+            if granularity is Granularity.MONTHLY:
+                deposit_year = deposit_years[period]
+                deposit = config.monthly_deposit * (1.0 + config.inflation) ** deposit_year
+                balance_nominal += deposit
+            else:
+                is_month_end = (period == periods - 1) or (
+                    deposit_years[period + 1] > deposit_years[period]
+                )
+                if is_month_end:
+                    deposit_year = deposit_years[period]
+                    deposit = config.monthly_deposit * (1.0 + config.inflation) ** deposit_year
+                    balance_nominal += deposit
+
+            real_balance = balance_nominal / inflation_factor[period]
+            paths_real[sim_idx, period] = real_balance
+
+            if not crossed and real_balance >= config.target_real:
+                crossing_index[sim_idx] = period
+                crossed = True
+
+    return SimulationResult(
+        paths_real=paths_real,
+        crossing_index=crossing_index,
+        years_axis=years_axis,
+        periods_per_year=periods_per_year,
+        target=config.target_real,
+    )
+
+
+def run_simulation(
+    sim_config: SimulationConfig,
+    model_config: ReturnModelConfig,
+) -> SimulationResult:
+    """Run the requested simulation and return the full result set."""
+
+    rng = default_rng(sim_config.seed)
+    return _run_simulation(sim_config, model_config, sim_config.granularity, rng=rng)
+
+
+def run_monthly_simulation(
+    sim_config: SimulationConfig,
+    model_config: ReturnModelConfig,
+) -> SimulationResult:
+    config = replace(sim_config, granularity=Granularity.MONTHLY)
+    rng = default_rng(config.seed)
+    return _run_simulation(config, model_config, Granularity.MONTHLY, rng=rng)
+
+
+def run_daily_simulation(
+    sim_config: SimulationConfig,
+    model_config: ReturnModelConfig,
+) -> SimulationResult:
+    config = replace(sim_config, granularity=Granularity.DAILY)
+    rng = default_rng(config.seed)
+    return _run_simulation(config, model_config, Granularity.DAILY, rng=rng)
+
+
+def find_cross_index(series: np.ndarray, threshold: float) -> int:
+    indices = np.nonzero(series >= threshold)[0]
+    if indices.size == 0:
+        return -1
+    return int(indices[0])

--- a/src/isk_montecarlo/tax.py
+++ b/src/isk_montecarlo/tax.py
@@ -1,0 +1,136 @@
+"""Utilities for exploring Swedish income tax and pension contributions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True, slots=True)
+class TaxParameters:
+    """Container for the 2025 Stockholm tax and pension settings."""
+
+    pbb: float = 58_800.0
+    ibb: float = 80_600.0
+    municipal_rate: float = 0.3060
+    state_rate: float = 0.20
+    skiktgrans: float = 625_800.0
+    brytpunkt: float = 643_100.0
+    burial_fee: float = 0.00070
+    public_service_max: float = 1_249.0
+    public_service_rate: float = 0.01
+    public_pension_rate: float = 0.185
+    pgi_rate: float = 0.93
+    pgi_ceiling: float = 7.5 * ibb
+    btp1_rate_low: float = 0.065
+    btp1_rate_high: float = 0.32
+    btp1_low_ceiling: float = 7.5 * ibb
+    btp1_high_ceiling: float = 30.0 * ibb
+    fee_cap: float = 8.07 * ibb
+
+    months_per_year: int = 12
+
+
+def grundavdrag(ffi: np.ndarray, params: TaxParameters) -> np.ndarray:
+    ffi_pbb = ffi / params.pbb
+    ga = np.empty_like(ffi)
+    ga[ffi_pbb <= 0.99] = 0.423
+    mask = (ffi_pbb > 0.99) & (ffi_pbb <= 2.72)
+    ga[mask] = 0.225 + 0.2 * ffi_pbb[mask]
+    mask = (ffi_pbb > 2.72) & (ffi_pbb <= 3.11)
+    ga[mask] = 0.770
+    mask = (ffi_pbb > 3.11) & (ffi_pbb <= 7.88)
+    ga[mask] = 1.081 - 0.1 * ffi_pbb[mask]
+    ga[ffi_pbb > 7.88] = 0.293
+    return ga * params.pbb
+
+
+def jobbskatteavdrag(ai: np.ndarray, ga: np.ndarray, params: TaxParameters) -> np.ndarray:
+    pbb = params.pbb
+    base = np.zeros_like(ai)
+    mask = ai <= 0.91 * pbb
+    base[mask] = ai[mask] - ga[mask]
+    mask = (ai > 0.91 * pbb) & (ai <= 3.24 * pbb)
+    base[mask] = 0.91 * pbb + 0.3874 * (ai[mask] - 0.91 * pbb) - ga[mask]
+    mask = (ai > 3.24 * pbb) & (ai <= 8.08 * pbb)
+    base[mask] = 1.813 * pbb + 0.199 * (ai[mask] - 3.24 * pbb) - ga[mask]
+    mask = ai > 8.08 * pbb
+    base[mask] = 2.776 * pbb - ga[mask]
+    base = np.maximum(base, 0.0)
+    return params.municipal_rate * base
+
+
+@dataclass(slots=True)
+class TaxProfiles:
+    gross_monthly: np.ndarray
+    net_monthly: np.ndarray
+    total_tax_annual: np.ndarray
+    average_rate: np.ndarray
+    marginal_rate: np.ndarray
+    public_pension: np.ndarray
+    btp1_low: np.ndarray
+    btp1_high: np.ndarray
+    btp1_total: np.ndarray
+    params: TaxParameters
+
+    def monthly_breakpoints(self) -> dict[str, float]:
+        return {
+            "PGI cap": self.params.pgi_ceiling / self.params.months_per_year,
+            "BTP1 7.5 IBB": self.params.btp1_low_ceiling / self.params.months_per_year,
+            "BTP1 30 IBB": self.params.btp1_high_ceiling / self.params.months_per_year,
+            "State tax": self.params.brytpunkt / self.params.months_per_year,
+            "Fee cap": self.params.fee_cap / self.params.months_per_year,
+        }
+
+
+def compute_profiles(
+    gross_monthly: np.ndarray,
+    *,
+    params: TaxParameters = TaxParameters(),
+) -> TaxProfiles:
+    months = params.months_per_year
+    gross_annual = gross_monthly * months
+    ffi = gross_annual
+    ga = grundavdrag(ffi, params)
+    taxable = np.maximum(ffi - ga, 0.0)
+
+    municipal_tax = params.municipal_rate * taxable
+    jsa = jobbskatteavdrag(ffi, ga, params)
+    jsa_capped = np.minimum(jsa, municipal_tax)
+    state_tax = params.state_rate * np.maximum(taxable - params.skiktgrans, 0.0)
+    burial_fee = params.burial_fee * taxable
+    public_service = np.minimum(params.public_service_rate * taxable, params.public_service_max)
+
+    total_tax_annual = (municipal_tax - jsa_capped) + state_tax + burial_fee + public_service
+    net_annual = gross_annual - total_tax_annual
+    net_monthly = net_annual / months
+
+    average_rate = np.divide(
+        total_tax_annual, gross_annual, out=np.zeros_like(total_tax_annual), where=gross_annual > 0
+    )
+    marginal_rate = np.clip(np.gradient(total_tax_annual, gross_annual, edge_order=2), 0.0, 1.0)
+
+    pgi_monthly = np.minimum(params.pgi_rate * gross_monthly, params.pgi_ceiling / months)
+    public_pension = params.public_pension_rate * pgi_monthly
+
+    btp1_low = params.btp1_rate_low * np.minimum(gross_monthly, params.btp1_low_ceiling / months)
+    btp1_high = params.btp1_rate_high * np.clip(
+        gross_monthly - params.btp1_low_ceiling / months,
+        0.0,
+        params.btp1_high_ceiling / months - params.btp1_low_ceiling / months,
+    )
+    btp1_total = btp1_low + btp1_high
+
+    return TaxProfiles(
+        gross_monthly=gross_monthly,
+        net_monthly=net_monthly,
+        total_tax_annual=total_tax_annual,
+        average_rate=average_rate,
+        marginal_rate=marginal_rate,
+        public_pension=public_pension,
+        btp1_low=btp1_low,
+        btp1_high=btp1_high,
+        btp1_total=btp1_total,
+        params=params,
+    )


### PR DESCRIPTION
## Summary
- add a shared examples/_paths helper that injects the repo's src directory onto sys.path when modules are imported
- update the example scripts to import the helper so they can locate the isk_montecarlo package when run directly

## Testing
- ruff format .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68ced081073c832f8f7b39758de6df6a